### PR TITLE
Refactor : 드래그 앤 드랍 영역을 카드 전체에서 핸들로 변경

### DIFF
--- a/src/components/group/recruit/GroupItemCard/GroupItemCard.styles.ts
+++ b/src/components/group/recruit/GroupItemCard/GroupItemCard.styles.ts
@@ -24,6 +24,11 @@ export const GroupItemCard = styled.div`
 
   &.registed {
     margin-bottom: 12px;
+    padding: 22px 23px 22px 10px;
+  }
+
+  .handle {
+    margin-right: 5px;
   }
 `;
 

--- a/src/components/group/recruit/GroupItemCard/index.tsx
+++ b/src/components/group/recruit/GroupItemCard/index.tsx
@@ -6,7 +6,7 @@ import { mapOptionState, selectedPlaceState } from '@/recoil/GroupRegistState';
 import { findLabelByCode } from '@/utils/findCodeByLabel';
 import { CATEGORY_OPTION } from '@/constants/area';
 
-import { RiFlag2Line, RiFlag2Fill } from 'react-icons/ri';
+import { RiFlag2Line, RiFlag2Fill, RiDraggable } from 'react-icons/ri';
 import Button from '@/components/Button';
 import * as S from './GroupItemCard.styles';
 import theme from '@/assets/styles/theme';
@@ -158,8 +158,14 @@ function GroupItemCard({ item, index, type = 'search' }: GroupItemCardProps) {
               onClick={handleMapCenter}
               ref={provided.innerRef}
               {...provided.draggableProps}
-              {...provided.dragHandleProps}
+              // {...provided.dragHandleProps}
             >
+              <span className="handle" {...provided.dragHandleProps}>
+                <RiDraggable
+                  style={{ cursor: 'grab', minWidth: '18px', height: '18px' }}
+                />
+              </span>
+
               {type === 'registed' && (
                 <S.GroupItemCardOrder
                   className={getOrderClassName(categoryText)}


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 그룹 모집 페이지에서 등록된 카드에는 클릭 이벤트, 드래그 이벤트 둘 다 존재
- 드래그 앤 드랍이 가능하다는 사실을 유저에게 직관적으로 보여주기 위해 드래그 핸들을 추가하고, 드래그 영역을 핸들로 고정

<img width="426" alt="image" src="https://github.com/ValueWith/ValueWith_FE/assets/110911811/33f5fdad-2d1e-4fcd-95d4-9326d2d9ee26">
