### PR TITLE
Design: 그룹 상세 페이지 스타일 수정

### DIFF
--- a/src/components/TripCard/index.tsx
+++ b/src/components/TripCard/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import GroupUserInfo from '../GroupUserInfo';
 import GroupMemberManagement from '../GroupMemberManagement';
+import TripCardUserInfo from '../TripCardUserInfo';
 
 import { TripGroup } from '@/apis/group';
 import { calculateDday } from '@/utils/dateUtil.ts';
@@ -55,7 +56,7 @@ function TripCard({ group, cardType }: TripCardProps) {
         }}
       >
         {isClosed && <S.Closed />}
-        <S.CardTumbnail src={thumbnailUrl} alt="지도 썸네일" />
+        <S.CardTumbnail src={thumbnailUrl} alt='지도 썸네일' />
         <S.IconContainer>
           <S.Icon>
             <FaMapMarkerAlt />
@@ -111,7 +112,7 @@ function TripCard({ group, cardType }: TripCardProps) {
               gender={gender}
             />
 
-            <GroupUserInfo
+            <TripCardUserInfo
               profileUrl={profileUrl}
               nickName={nickName}
               age={age}

--- a/src/components/TripCardUserInfo/TripCardUserInfo.styles.ts
+++ b/src/components/TripCardUserInfo/TripCardUserInfo.styles.ts
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+export const ProfileContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  > span {
+    font-size: 14px;
+    letter-spacing: -0.7px;
+    color: #1c1c1c;
+  }
+`;
+
+export const ProfileImage = styled.img`
+  width: 32px;
+  height: 32px;
+  margin-right: 9px;
+  border-radius: 100%;
+`;

--- a/src/components/TripCardUserInfo/index.tsx
+++ b/src/components/TripCardUserInfo/index.tsx
@@ -1,0 +1,29 @@
+import { CSSProperties } from 'react';
+import * as S from './TripCardUserInfo.styles';
+
+interface TripCardUserInfoProps {
+  profileUrl: string;
+  nickName: string;
+  age: number;
+  gender: string;
+  style?: CSSProperties;
+}
+
+function TripCardUserInfo({
+  profileUrl,
+  nickName,
+  age,
+  gender,
+  style,
+}: TripCardUserInfoProps) {
+  return (
+    <S.ProfileContainer style={{ ...style }}>
+      <S.ProfileImage src={profileUrl} alt='프로필 이미지' />
+      <span style={{ ...style }}>
+        {nickName}&nbsp;&#183;&nbsp;{age}&nbsp;&#183;&nbsp;{gender}성
+      </span>
+    </S.ProfileContainer>
+  );
+}
+
+export default TripCardUserInfo;

--- a/src/components/group/detail/GroupMemberStatus/GroupMemberStatus.styles.ts
+++ b/src/components/group/detail/GroupMemberStatus/GroupMemberStatus.styles.ts
@@ -41,7 +41,7 @@ export const GroupMemberStatusModal = styled.div`
 `;
 
 export const ModalTitle = styled.p`
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 500;
   letter-spacing: -0.8px;
   color: #1c1c1c;

--- a/src/components/group/detail/GroupMemberStatus/GroupMemberStatus.styles.ts
+++ b/src/components/group/detail/GroupMemberStatus/GroupMemberStatus.styles.ts
@@ -6,7 +6,7 @@ export const GroupMemberStatusContainer = styled.div`
   height: 138px;
   background-color: #fafafa;
   border-radius: 4px;
-  padding: 24px 0 0 27px;
+  padding: 24px 21px;
   margin-top: 40px;
 `;
 
@@ -15,7 +15,7 @@ export const ContentDiv = styled.div`
   gap: 21px;
   letter-spacing: -0.8px;
   margin-bottom: 8px;
-  font-size: 16px;
+  font-size: 15px;
   position: relative;
 `;
 

--- a/src/components/group/detail/GroupMemberStatus/index.tsx
+++ b/src/components/group/detail/GroupMemberStatus/index.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { calculateDday, formatDotDate } from '@/utils/dateUtil';
 import { GroupMember } from '@/apis/groupDetail';
-import GroupUserInfo from '@/components/GroupUserInfo';
+import TripCardUserInfo from '@components/TripCardUserInfo';
 
 import { AiFillCaretDown, AiFillCaretUp } from 'react-icons/ai';
 import * as S from './GroupMemberStatus.styles';
@@ -54,7 +54,7 @@ function GroupMemberStatus({
             <S.ModalTitle>함께하는 멤버</S.ModalTitle>
             {groupMembers &&
               groupMembers.map((member) => (
-                <GroupUserInfo
+                <TripCardUserInfo
                   key={member.groupMemberNickname}
                   profileUrl={member.groupMemberProfileUrl}
                   nickName={member.groupMemberNickname}
@@ -73,7 +73,7 @@ function GroupMemberStatus({
         </S.Content>
       </S.ContentDiv>
       <div className='mt-[20px]'>
-        <GroupUserInfo
+        <TripCardUserInfo
           profileUrl={profileUrl}
           nickName={nickName}
           age={Number(age)}

--- a/src/components/group/detail/GroupMemberStatus/index.tsx
+++ b/src/components/group/detail/GroupMemberStatus/index.tsx
@@ -60,7 +60,7 @@ function GroupMemberStatus({
                   nickName={member.groupMemberNickname}
                   age={Number(member.groupMemberAge)}
                   gender={member.groupMemberGender}
-                  style={{ marginBottom: '5px' }}
+                  style={{ marginBottom: '5px', fontSize: '15px' }}
                 />
               ))}
           </S.GroupMemberStatusModal>

--- a/src/components/group/detail/TripPlaceCard/TripPlaceCard.styles.ts
+++ b/src/components/group/detail/TripPlaceCard/TripPlaceCard.styles.ts
@@ -3,11 +3,9 @@ import styled from '@emotion/styled';
 
 export const TripPlaceCardContainer = styled.div`
   width: 100%;
-  min-height: 65px;
   display: flex;
   align-items: center;
   padding: 0 56.5px;
-  margin-bottom: 6px;
 
   &:last-of-type {
     margin-bottom: 0;
@@ -19,7 +17,7 @@ export const TripPlaceCardOrder = styled.span`
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  width: 25px;
+  min-width: 25px;
   height: 25px;
   margin-right: 12px;
   background-color: #f87973;


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- TripCardUserInfo 생성
  - 그룹 관리 페이지에 들어가는 GroupUserInfo 컴포넌트와 용도가 다르다고 판단해, 컴포넌트를 따로 생성했습니다.
- 그룹 상세 페이지에서 멤버 모집 현황 div에 padding을 양 옆이 동일하게 지정했습니다.
  - 폰트 사이즈를 16에서 15로 수정했습니다.
- TripPlaceCard 컴포넌트에서 장소 순서를 동그라미로 나타내기 위해 min-width를 지정했습니다.
