### PR TITLE
Feat : 토큰 만료시 자동 로그인 연장

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
+import { tokenRefreshRequest } from './user';
 
 const baseURL = 'http://localhost:5173';
 
 const instance = axios.create({
   baseURL,
-  headers: { 'Content-Type': 'application/json; charset=utf-8' },
+  headers: { 'Content-Type': 'application/json' },
   withCredentials: true,
 });
 
@@ -18,18 +19,50 @@ instance.interceptors.request.use((config) => {
   return config;
 });
 
+export const getToken = async () => {
+  try {
+    const response = await instance.post('/api/auth/refresh');
+    localStorage.setItem('accessToken', response.data.accessToken);
+
+    return response.data.accessToken;
+  } catch (e) {
+    console.log(e);
+  }
+};
+
 instance.interceptors.response.use(
   (response) => response,
   async (error) => {
-    const { response } = error;
+    const { config, response } = error;
+
+    // config.url이 /auth/token/refresh이면 토큰 갱신 요청이므로 중단
+    // config._retry가 true이면 토큰 갱신 후 재요청이므로 중단(무한루프 방지 플래그)
+    // 내부 속성이므로 플래그 이름에 _를 붙여 구분
+    if (config.url === '/auth/token/refresh' || config._retry) {
+      return Promise.reject(error);
+    }
 
     if (response && response.status) {
+      if (response.status === 401) {
+        config._retry = true;
+        const accessToken = await tokenRefreshRequest();
+
+        // 토큰이 재발급 되었으면 헤더에 새로운 토큰을 넣어준다
+        if (accessToken) {
+          config.headers.Authorization = `${accessToken}`;
+
+          // 액세스 토큰과 유저 정보를 로컬 스토리지에 저장
+          localStorage.setItem('accessToken', response.data.accessToken);
+        }
+
+        // 중단된 요청을 토큰 갱신 후 재요청
+        return instance(config);
+      }
+
       switch (response.status) {
         case 400:
         case 404:
           return Promise.reject('API 요청에 실패했습니다.');
-        case 401:
-          return Promise.reject('로그인이 필요합니다.');
         case 500:
           return Promise.reject('서버에 오류가 발생했습니다.');
         default:

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -4,10 +4,8 @@ import { LoginProps, SignUpProps } from './user.model';
 // 이메일 인증 코드 요청
 export const verifyEmail = async (email: string): Promise<void> => {
   try {
-    const response = await instance.post('/api/auth/verify', null, {
-      params: {
-        email: email,
-      },
+    const response = await instance.post('/api/auth/verify', {
+      email,
     });
     return response.data;
   } catch (error) {
@@ -18,11 +16,9 @@ export const verifyEmail = async (email: string): Promise<void> => {
 // 이메일 인증 코드 확인
 export const verifyEmailCheck = async (email: string, code: string) => {
   try {
-    const response = await instance.post('/api/auth/verify/check', null, {
-      params: {
-        email,
-        code,
-      },
+    const response = await instance.post('/api/auth/verify/check', {
+      email,
+      code,
     });
     return response.data;
   } catch (error) {

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -43,6 +43,18 @@ export const signupRequest = async (data: SignUpProps, formData?: any) => {
 };
 
 // 로그인
-export function loginRequest(data: LoginProps) {
+export const loginRequest = (data: LoginProps) => {
   return instance.post('/api/auth/signin', data);
-}
+};
+
+// 토큰 갱신
+export const tokenRefreshRequest = async () => {
+  try {
+    const response = await instance.post('/api/auth/refresh');
+    localStorage.setItem('accessToken', response.data.accessToken);
+
+    return response.data.accessToken;
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/src/components/Header/Header.styles.ts
+++ b/src/components/Header/Header.styles.ts
@@ -27,7 +27,7 @@ export const HeaderMenu = styled.nav`
   align-items: center;
   margin-left: 68px;
 
-  .header__menu-list {
+  .list {
     display: inline-flex;
     align-items: center;
     height: 100%;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -75,6 +75,7 @@ function Header() {
           isModalOpen: false,
         });
         localStorage.removeItem('accessToken');
+        localStorage.removeItem('userInfo');
         setIsLogin(false);
         navigate('/');
       },
@@ -110,7 +111,7 @@ function Header() {
 
         {/* 헤더 메뉴 */}
         <S.HeaderMenu>
-          <ul className='header__menu-list'>
+          <ul className="list">
             {PAGE_LINK.map((page, index) => {
               return (
                 <S.HeaderMenuItem
@@ -151,12 +152,12 @@ function Header() {
                 <AiOutlineBell size={24} />
               </S.UserActionItem>
 
-              <span className='ml-4'>|</span>
+              <span className="ml-4">|</span>
 
               <Button
-                type='button'
-                styleType='text'
-                className='ml-4'
+                type="button"
+                styleType="text"
+                className="ml-4"
                 style={{
                   minWidth: 'auto',
                   color: `${theme.color.fontgray}`,
@@ -169,8 +170,8 @@ function Header() {
             </S.UserActions>
           ) : (
             <Button
-              type='button'
-              styleType='basic'
+              type="button"
+              styleType="basic"
               onClickHandler={handleLogin}
             >
               로그인

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -96,11 +96,14 @@ function useAuth() {
 
     try {
       const response = await loginRequest(data);
-      localStorage.setItem('accessToken', response.data);
+      localStorage.setItem('accessToken', response.data.accessToken);
+      localStorage.setItem(
+        'userInfo',
+        JSON.stringify(response.data.loginMemberIdDto)
+      );
       setIsLogin(true);
       navigate('/');
     } catch (error) {
-      // TODO : 회원가입이 안 된 경우, 비밀번호가 틀린 경우 등 에러 처리
       setIsLoading(false);
       setIsError(true);
 


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
### 토큰 만료시 자동 로그인 연장
- 토큰이 필요한 요청에서 액세스 토큰이 만료되어 401 에러가 발생하면 토큰을 새로 발급받고, 중단된 요청을 다시 시도

### 로그인 시 return 값으로 유저 정보 추가
- localStorage에 userInfo key로 저장
- 로그아웃 시 액세스 토큰과 userInfo 모두 삭제 


---
[로그인 연장 레퍼런스1 : 로그인 연장 - axios interceptors 사용하기](https://velog.io/@marksen/%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%97%B0%EC%9E%A5-axios-interceptors-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0#3-api-%ED%98%B8%EC%B6%9C%ED%95%98%EB%8A%94-%ED%95%A8%EC%88%98-%EC%9E%91%EC%84%B1)
[로그인 연장 레퍼런스2 : 만료된 accessToken을 RefreshToken을 통해 새 accessToken으로 받아오기](https://velog.io/@tchaikovsky/axios%EB%A7%8C%EB%A3%8C%EB%90%9C-accessToken%EC%9D%84-RefreshToken%EC%9D%84-%ED%86%B5%ED%95%B4-%EC%83%88-accessToken%EC%9C%BC%EB%A1%9C-%EB%B0%9B%EC%95%84%EC%98%A4%EA%B8%B0)