### PR TITLE
Refactor : 마지막 카드에서는 하단 줄 뜨지 않도록 수정, distance가 null일때는 화살표 감춤 처리

### DIFF
--- a/src/components/group/detail/TripPlaceCard/index.tsx
+++ b/src/components/group/detail/TripPlaceCard/index.tsx
@@ -4,6 +4,9 @@ import { getMarkerBackground } from '@/utils/getMarkerBackground';
 import { AiFillCaretRight } from 'react-icons/ai';
 import * as S from './TripPlaceCard.styles';
 
+interface TripPlaceCardProps extends Place {
+  isLast?: boolean;
+}
 function TripPlaceCard({
   category,
   name,
@@ -13,7 +16,8 @@ function TripPlaceCard({
   placeCode,
   orders,
   distance,
-}: Place) {
+  isLast,
+}: TripPlaceCardProps) {
   const markerColor = getMarkerBackground(category);
   return (
     <div>
@@ -31,11 +35,17 @@ function TripPlaceCard({
           </S.TripPlaceCardDetailInfo>
         </S.TripPlaceCardInfo>
       </S.TripPlaceCardContainer>
-      {distance !== null && (
+      {!isLast && (
         <S.TripPlaceDistanceContainer>
           <div className="flex items-center w-[56px] justify-end">
-            <S.TripPlaceDistance>{distance}km</S.TripPlaceDistance>
-            <AiFillCaretRight style={{ fontSize: '12px', marginLeft: '3px' }} />
+            {distance != null && (
+              <>
+                <S.TripPlaceDistance>{distance}km</S.TripPlaceDistance>
+                <AiFillCaretRight
+                  style={{ fontSize: '12px', marginLeft: '3px' }}
+                />
+              </>
+            )}
           </div>
           <S.TripPlaceDistanceLine />
         </S.TripPlaceDistanceContainer>

--- a/src/components/group/detail/TripPlaceList/index.tsx
+++ b/src/components/group/detail/TripPlaceList/index.tsx
@@ -11,7 +11,7 @@ function TripPlaceList({ places }: TripPlaceListProps) {
   return (
     <S.TripPlaceListContainer>
       {places &&
-        places.map((place: Place) => (
+        places.map((place: Place, index: number) => (
           <TripPlaceCard
             key={place.orders}
             category={place.category}
@@ -22,6 +22,7 @@ function TripPlaceList({ places }: TripPlaceListProps) {
             placeCode={place.placeCode}
             orders={place.orders}
             distance={place.distance}
+            isLast={index === places.length - 1}
           />
         ))}
     </S.TripPlaceListContainer>


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
❗️ 추천 경로에서 distance가 마지막이 아니어도 null이 들어올 수 있는 것을 확인했습니다!
- distance가 전부 없을 때도 마지막 카드에서 거리 표시가 뜨지 않도록 수정했습니다 