### PR TITLE
Fix : 그룹 모집이 성공하면, 선택한 장소 데이터를 Reset

### DIFF
--- a/src/hooks/useRegist.tsx
+++ b/src/hooks/useRegist.tsx
@@ -71,6 +71,7 @@ export const useRegistGroup = () => {
   const navigate = useNavigate();
   const [modalDataState, setModalDataState] = useRecoilState(modalState);
   const [tempFormData, setTempFormData] = useRecoilState(tempFormState);
+  const setSelectedPlace = useSetRecoilState(selectedPlaceState);
   const [isSubmitLoading, setIsSubmitLoading] = useState(false);
 
   const handleFilterArea = (data: any) => {
@@ -153,6 +154,7 @@ export const useRegistGroup = () => {
       });
 
       setTempFormData({});
+      setSelectedPlace({ selectedPlace: [] });
 
       // 알럿 띄우기
     } catch (error) {


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 그룹 모집에 성공하면 선택된 데이터를 초기화해서, 다시 페이지에 접근했을 때 장소를 새로 선택할 수 있도록 수정 