### PR TITLE
Feat : 그룹 상세 페이지 지도 추가 

### DIFF
--- a/src/components/group/detail/TripPlaceCard/index.tsx
+++ b/src/components/group/detail/TripPlaceCard/index.tsx
@@ -1,12 +1,17 @@
 import { Place } from '@/apis/groupDetail';
+
+import { useRecoilState } from 'recoil';
+import { mapOptionState } from '@/recoil/GroupRegistState';
+
+import { metersToKilometers } from '@/utils/metersToKilometers';
 import { getMarkerBackground } from '@/utils/getMarkerBackground';
 
 import { AiFillCaretRight } from 'react-icons/ai';
 import * as S from './TripPlaceCard.styles';
-import { metersToKilometers } from '@/utils/metersToKilometers';
 
 interface TripPlaceCardProps extends Place {
   isLast?: boolean;
+  onClickHandler?: () => void;
 }
 function TripPlaceCard({
   category,
@@ -18,13 +23,23 @@ function TripPlaceCard({
   orders,
   distance,
   isLast,
+  onClickHandler,
 }: TripPlaceCardProps) {
+  const [mapOptions, setMapOptions] = useRecoilState(mapOptionState);
+
+  const handleMapOption = () => {
+    setMapOptions({
+      ...mapOptions,
+      center: { lat: y, lng: x },
+    });
+  };
+
   const markerColor = getMarkerBackground(category);
   const kilometers = metersToKilometers(distance);
 
   return (
     <div>
-      <S.TripPlaceCardContainer>
+      <S.TripPlaceCardContainer onClick={handleMapOption}>
         <S.TripPlaceCardOrder style={{ backgroundColor: markerColor }}>
           {orders}
         </S.TripPlaceCardOrder>
@@ -40,7 +55,7 @@ function TripPlaceCard({
       </S.TripPlaceCardContainer>
       {!isLast && (
         <S.TripPlaceDistanceContainer>
-          <div className='flex items-center w-[56px] justify-end'>
+          <div className="flex items-center w-[56px] justify-end">
             {distance != null && (
               <>
                 <S.TripPlaceDistance>{kilometers}&nbsp;km</S.TripPlaceDistance>

--- a/src/components/group/recruit/GroupNavSidebar/index.tsx
+++ b/src/components/group/recruit/GroupNavSidebar/index.tsx
@@ -3,7 +3,7 @@ import Logo from '@assets/TweaverLogo.svg?react';
 import * as S from './GroupNavSidebar.styles';
 import theme from '@/assets/styles/theme';
 import { useEffect } from 'react';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { tempFormState } from '@/recoil/GroupRegistState';
 
 const RECRUIT_STEP = [
@@ -28,7 +28,7 @@ function GroupNavSidebar({
 }: GroupNavSidebarProps) {
   const navigate = useNavigate();
 
-  const [tempFormData, setTempFormData] = useRecoilState(tempFormState);
+  const setTempFormData = useSetRecoilState(tempFormState);
 
   useEffect(() => {
     setTempFormData(null);

--- a/src/components/group/recruit/KakaoMap/index.tsx
+++ b/src/components/group/recruit/KakaoMap/index.tsx
@@ -10,9 +10,13 @@ import { useRecoilState } from 'recoil';
 
 import { getMarkerBackground } from '@/utils/getMarkerBackground';
 import { mapOptionState, selectedPlaceState } from '@/recoil/GroupRegistState';
+import { useLocation } from 'react-router-dom';
 
-function KakaoMap() {
-  const [selectedPlaceData] = useRecoilState(selectedPlaceState);
+function KakaoMap({ isDetail }: { isDetail?: boolean }) {
+  const location = useLocation();
+
+  const [selectedPlaceData, setSelectedPlaceData] =
+    useRecoilState(selectedPlaceState);
   const [mapOptions, setMapOptions] = useRecoilState(mapOptionState);
 
   // 맵 마커는 selectedPlaceData.selectedPlace에 없을 때만 렌더링
@@ -25,27 +29,49 @@ function KakaoMap() {
   );
 
   useEffect(() => {
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          const { latitude, longitude } = position.coords;
+    const isRecruit = location.pathname.startsWith('/group/recruit');
 
-          setMapOptions({
-            ...mapOptions,
-            center: { lat: latitude, lng: longitude },
-          });
-        },
-        (error) => {
-          console.error(error);
-        },
-        {
-          enableHighAccuracy: true,
-          maximumAge: 0,
-          timeout: Infinity, // 위치 정보를 가져오는데 걸리는 시간 제한 없음
-        }
-      );
+    if (isRecruit) {
+      setSelectedPlaceData({ selectedPlace: [] });
+
+      // 초기화 -> 상세 페이지에서 첫번째 장소로 지도 중심 설정하고 있어서 초기화 필요
+      setMapOptions({
+        ...mapOptions,
+        center: { lat: 0, lng: 0 },
+      });
+
+      if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const { latitude, longitude } = position.coords;
+
+            setMapOptions({
+              ...mapOptions,
+              center: { lat: latitude, lng: longitude },
+            });
+          },
+          (error) => {
+            console.error(error);
+          },
+          {
+            enableHighAccuracy: true,
+            maximumAge: 0,
+            timeout: Infinity, // 위치 정보를 가져오는데 걸리는 시간 제한 없음
+          }
+        );
+      }
+    } else if (!isRecruit) {
+      if (selectedPlaceData.selectedPlace.length > 0) {
+        setMapOptions({
+          ...mapOptions,
+          center: {
+            lat: selectedPlaceData.selectedPlace[0].y,
+            lng: selectedPlaceData.selectedPlace[0].x,
+          },
+        });
+      }
     }
-  }, []);
+  }, [isDetail]);
 
   return (
     <Map

--- a/src/components/group/recruit/KakaoMap/index.tsx
+++ b/src/components/group/recruit/KakaoMap/index.tsx
@@ -11,6 +11,7 @@ import { useRecoilState } from 'recoil';
 import { getMarkerBackground } from '@/utils/getMarkerBackground';
 import { mapOptionState, selectedPlaceState } from '@/recoil/GroupRegistState';
 import { useLocation } from 'react-router-dom';
+import Loader from '@/components/Loader';
 
 function KakaoMap({ isDetail }: { isDetail?: boolean }) {
   const location = useLocation();
@@ -51,7 +52,9 @@ function KakaoMap({ isDetail }: { isDetail?: boolean }) {
             });
           },
           (error) => {
-            console.error(error);
+            setMapOptions({
+              ...mapOptions,
+            });
           },
           {
             enableHighAccuracy: true,
@@ -119,7 +122,15 @@ function KakaoMap({ isDetail }: { isDetail?: boolean }) {
         />
       )}
 
-      {shouldRenderMapMarker && <MapMarker position={mapOptions.center} />}
+      {shouldRenderMapMarker &&
+        (mapOptions.center.lat !== 0 && mapOptions.center.lng !== 0 ? (
+          <MapMarker position={mapOptions.center} />
+        ) : (
+          <>
+            현재 위치를 찾고 있습니다. 잠시만 기다려주세요
+            <Loader width={30} height={30} className="z-[1]" />
+          </>
+        ))}
     </Map>
   );
 }

--- a/src/pages/group/GroupDetail/index.tsx
+++ b/src/pages/group/GroupDetail/index.tsx
@@ -11,13 +11,19 @@ import TripPlaceList from '@/components/group/detail/TripPlaceList';
 
 import * as S from './GroupDetail.styles';
 import ApplyButton from '@/components/group/detail/ApplyButton';
+import KakaoMap from '@/components/group/recruit/KakaoMap';
+
 import { checkApplicationStatus } from '@/utils/checkApplicationStatus';
+import { useRecoilState } from 'recoil';
+import { mapOptionState, selectedPlaceState } from '@/recoil/GroupRegistState';
 
 function GroupDetail() {
   const { groupId } = useParams();
 
   const userInfoString = localStorage.getItem('userInfo');
   const [userStatus, setUserStatus] = useState<string>('');
+  const [selectedPlace, setSelectedPlace] = useRecoilState(selectedPlaceState);
+  const [isDetail, setIsDetail] = useState<boolean>(false);
 
   const { data, isLoading, isError } = useGroupDetailDataFetching(
     Number(groupId)
@@ -30,9 +36,11 @@ function GroupDetail() {
 
       if (data) {
         setUserStatus(checkApplicationStatus(data, memberEmail));
+        setSelectedPlace({ selectedPlace: data.places });
+        setIsDetail(true);
       }
     }
-  }, [userInfoString, data]);
+  }, [userInfoString, data, setSelectedPlace]);
 
   return (
     <>
@@ -41,7 +49,13 @@ function GroupDetail() {
       {data && (
         <S.GroupDetailContainer>
           <GroupTitle title={data.tripGroupDetail.name} />
-          <S.GroupThumbnail src={data.tripGroupDetail.thumbnailUrl} />
+
+          {/* 카카오 지도  */}
+          <div className="w-full h-[500px] mt-6">
+            <KakaoMap isDetail={isDetail} />
+          </div>
+
+          {/* 그룹 멤버 정보 & 지원 정보  */}
           <S.GroupContentContainer>
             <div className="flex flex-col gap-3">
               <GroupMemberStatus
@@ -57,6 +71,7 @@ function GroupDetail() {
               <ApplyButton groupId={Number(groupId)} userStatus={userStatus} />
             </div>
 
+            {/* 그룹 내용  */}
             <div>
               <TripTitle
                 tripDate={data.tripGroupDetail.tripDate}

--- a/src/pages/group/GroupRecruit/index.tsx
+++ b/src/pages/group/GroupRecruit/index.tsx
@@ -27,7 +27,7 @@ function GroupRecruit() {
           )}
         </section>
       </div>
-      <div className="flex w-full">
+      <div className="flex w-full relative">
         <KakaoMap />
       </div>
     </main>

--- a/src/recoil/GroupRegistState.ts
+++ b/src/recoil/GroupRegistState.ts
@@ -33,8 +33,8 @@ export const mapOptionState = atom<MapOptionModel>({
   key: 'mapOptionState',
   default: {
     center: {
-      lat: 33.450701,
-      lng: 126.570667,
+      lat: 37.577613288258206,
+      lng: 126.97689786832184,
     },
     level: 3,
     isPanto: true,


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
### 상세 페이지
- 상세 페이지에서 썸네일 대신 지도가 보이도록 수정
- 각 카드를 클릭하면 지도의 위치 변경

### 그룹모집 페이지
- 상세 페이지에서 지도가 들어감에 따라 모집 페이지 초기화 코드 추가 
- geoLocation 거부되었을 때 예외 처리 추가 