### PR TITLE
Refactor : 로그인 확인 여부, 유저 정보 확인하는 로직을 커스텀 훅으로 분리

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -19,7 +19,7 @@ import DropdownMenu from '../DropdownMenu';
 import * as S from './Header.styles';
 import theme from '@/assets/styles/theme';
 import Logo from '@assets/TweaverLogo.svg?react';
-import { loginState } from '@/recoil/userState';
+import { useUser } from '@/hooks/useUser';
 
 function Header() {
   const location = useLocation();
@@ -27,16 +27,13 @@ function Header() {
 
   const [currentCategory, setCurrentCategory] = useState<string>('');
   const [isSubMenuVisible, setIsSubMenuVisible] = useState(true);
-  const [userInfo, setUserInfo] = useState({
-    memberId: 0,
-    memberNickname: '',
-    memberEmail: '',
-    memberProfileUrl: '',
-  });
 
   const setParams = useSetRecoilState(paramsState);
-  const [isLogin, setIsLogin] = useRecoilState<boolean>(loginState);
   const [modalDataState, setModalDataState] = useRecoilState(modalState);
+
+  const { userInfo, isLogin, setIsLogin } = useUser();
+
+  console.log(userInfo, 'userInfo');
 
   useEffect(() => {
     if (location.pathname.startsWith('/mylounge')) {
@@ -55,20 +52,6 @@ function Header() {
   useEffect(() => {
     setCurrentCategory(location.pathname);
   }, [location]);
-
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-
-    if (token) {
-      const userStorageInfo = localStorage.getItem('userInfo');
-      const userInfo = JSON.parse(userStorageInfo || '{}');
-
-      setIsLogin(true);
-      setUserInfo(userInfo);
-    } else {
-      setIsLogin(false);
-    }
-  }, [isLogin]);
 
   const handleLogin = () => {
     navigate('/login');

--- a/src/hooks/useUser.tsx
+++ b/src/hooks/useUser.tsx
@@ -1,0 +1,30 @@
+import { loginState } from '@/recoil/userState';
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+
+export const useUser = () => {
+  const [isLogin, setIsLogin] = useRecoilState<boolean>(loginState);
+
+  const [userInfo, setUserInfo] = useState({
+    memberId: 0,
+    memberNickname: '',
+    memberEmail: '',
+    memberProfileUrl: '',
+  });
+
+  useEffect(() => {
+    const token = localStorage.getItem('accessToken');
+    const userStorageInfo = localStorage.getItem('userInfo');
+
+    if (token) {
+      const userInfo = userStorageInfo ? JSON.parse(userStorageInfo) : {};
+
+      setIsLogin(true);
+      setUserInfo(userInfo);
+    } else {
+      setIsLogin(false);
+    }
+  }, [isLogin]);
+
+  return { isLogin, setIsLogin, userInfo };
+};

--- a/src/pages/group/GroupDetail/index.tsx
+++ b/src/pages/group/GroupDetail/index.tsx
@@ -16,6 +16,7 @@ import KakaoMap from '@/components/group/recruit/KakaoMap';
 import { checkApplicationStatus } from '@/utils/checkApplicationStatus';
 import { useRecoilState } from 'recoil';
 import { mapOptionState, selectedPlaceState } from '@/recoil/GroupRegistState';
+import { useUser } from '@/hooks/useUser';
 
 function GroupDetail() {
   const { groupId } = useParams();
@@ -29,9 +30,10 @@ function GroupDetail() {
     Number(groupId)
   );
 
+  const { userInfo } = useUser();
+
   useEffect(() => {
     if (userInfoString) {
-      const userInfo = JSON.parse(userInfoString);
       const memberEmail = userInfo.memberEmail;
 
       if (data) {


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 헤더 뿐만 아니라 상세 페이지, 마이 페이지 등 userInfo를 계속해서 꺼내서 사용해야 하기 때문에, 코드가 반복되지 않도록 커스텀 훅으로 분리
- useRecoil 로 분리하지 않은 이유 -> 전역 변수가 초기화되는 문제로 Recoil-persist 사용하면 로컬 스토리지에 다시 주입되기 때문에 