### PR TITLE
Refactor: 모달이 열려있을 때 화면을 클릭하면 닫히도록 수정

### DIFF
--- a/src/components/common/DropdownMenu/DropdownMenu.styles.ts
+++ b/src/components/common/DropdownMenu/DropdownMenu.styles.ts
@@ -5,6 +5,16 @@ export const DropdownMenuContainer = styled.div`
   position: relative;
 `;
 
+export const Dimmed = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  cursor: default;
+  z-index: 1;
+`;
+
 export const DropdownMenuList = styled.ul`
   position: absolute;
   top: 100%;

--- a/src/components/common/DropdownMenu/index.tsx
+++ b/src/components/common/DropdownMenu/index.tsx
@@ -17,27 +17,31 @@ function DropdownMenu({
   const handleOptionClick = (event: any, option: any) => {
     event.stopPropagation();
     option.onClickHandler();
+    setIsOpen(false);
   };
 
   return (
-    <S.DropdownMenuContainer className="dropdown-menu">
-      <div className="dropdown-menu__header" onClick={() => setIsOpen(!isOpen)}>
+    <S.DropdownMenuContainer className='dropdown-menu'>
+      <div className='dropdown-menu__header' onClick={() => setIsOpen(!isOpen)}>
         {children}
       </div>
       {isOpen && (
-        <S.DropdownMenuList
-          className="dropdown-menu__list"
-          style={dropdownMunuStyle}
-        >
-          {options.map((option: any, index: number) => (
-            <S.DropdownMenuItem
-              key={index}
-              onClick={(event) => handleOptionClick(event, option)}
-            >
-              {option.label}
-            </S.DropdownMenuItem>
-          ))}
-        </S.DropdownMenuList>
+        <>
+          <S.Dimmed onClick={() => setIsOpen(false)} />
+          <S.DropdownMenuList
+            className='dropdown-menu__list'
+            style={dropdownMunuStyle}
+          >
+            {options.map((option: any, index: number) => (
+              <S.DropdownMenuItem
+                key={index}
+                onClick={(event) => handleOptionClick(event, option)}
+              >
+                {option.label}
+              </S.DropdownMenuItem>
+            ))}
+          </S.DropdownMenuList>
+        </>
       )}
     </S.DropdownMenuContainer>
   );


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 프로필 클릭 시 모달, 마이라운지 카드 내에 모달을 관리하는 **DropdowmMenu** 컴포넌트를 수정했습니다.
- 모달 헤더를 클릭해야만 모달이 on/off가 되던 것이 이제는 모달이 열려있는 경우 화면 아무데나 클릭하면 모달이 닫힙니다.
- 추가로, 옵션을 클릭했을 경우 `setIsOpen(false)`를 통해 모달을 닫아주었습니다.
