### PR TITLE
Refactor: 마이라운지 마감된 그룹 하단 컨텐츠 클릭 가능하도록 수정

### DIFF
--- a/src/components/group/card/TripCard/TripCard.styles.ts
+++ b/src/components/group/card/TripCard/TripCard.styles.ts
@@ -39,6 +39,11 @@ export const Closed = styled.div`
     padding: 12px 14px;
     border-radius: 4px;
   }
+
+  .mylounge & {
+    height: calc(100% - 31px - 14px);
+    /* content height: 30px, border: 1px, padding: 14px */
+  }
 `;
 
 export const CardTumbnail = styled.img`


### PR DESCRIPTION
## PR 타입

- [ ] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
마감된 그룹 상세페이지 접근 관련
- 그룹페이지에서는 마감된 그룹 상세페이지 접근 가능
- 마이라운지에서는 마감된 그룹 상세페이지 접근 불가능
  > 디자인상의 이유!

- 마이라운지에서 `마감된 일정입니다` div를 하단 컨텐츠에는 포함되지 않도록 수정했습니다.
<img width="1206" alt="스크린샷 2024-01-15 오후 4 30 39" src="https://github.com/ValueWith/ValueWith_FE/assets/59556524/d79af71b-29d0-4382-9c9e-6191b3c920bf">

- 그룹페이지는 이전과 동일합니다.
<img width="295" alt="스크린샷 2024-01-15 오후 4 32 09" src="https://github.com/ValueWith/ValueWith_FE/assets/59556524/d28454f6-25b0-4807-8086-6aada6c2cc6b">
