### PR TITLE
Refactor: 비로그인 상태에서 그룹 상세페이지 접근 가능하도록 수정

### DIFF
--- a/src/components/group/detail/ApplyButton/index.tsx
+++ b/src/components/group/detail/ApplyButton/index.tsx
@@ -81,6 +81,19 @@ function ApplyButton({ tripGroupId, userStatus }: ApplyButtonProps) {
           마감
         </Button>
       )}
+
+      {/* 비로그인 상태 */}
+      {!userStatus && (
+        <Button
+          type='button'
+          styleType='solid'
+          style={isLoading ? { pointerEvents: 'none' } : {}}
+          fullWidth
+          onClickHandler={() => navigate('/login')}
+        >
+          지원하기
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/pages/group/GroupDetail/index.tsx
+++ b/src/pages/group/GroupDetail/index.tsx
@@ -57,18 +57,18 @@ function GroupDetail() {
     <>
       {isLoading && <Loader />}
       {isError && <div>Error...</div>}
-      {data && userInfo && (
+      {data && (
         <S.GroupDetailContainer>
           <GroupTitle title={data.tripGroupDetail.name} />
 
           {/* 카카오 지도  */}
-          <div className="w-full h-[500px] mt-6">
+          <div className='w-full h-[500px] mt-6'>
             <KakaoMap isDetail={isDetail} isError={isDetailError} />
           </div>
 
           {/* 그룹 멤버 정보 & 지원 정보  */}
           <S.GroupContentContainer>
-            <div className="flex flex-col gap-3">
+            <div className='flex flex-col gap-3'>
               <GroupMemberStatus
                 currentUserNumber={data.tripGroupDetail.currentUserNumber}
                 maxUserNumber={data.tripGroupDetail.maxUserNumber}


### PR DESCRIPTION
## PR 타입

- [x] 기능 추가
- [ ] 기능 변경
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 디자인 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 변경 사항
- 그룹 상세 페이지 컴포넌트에서 데이터에 `userInfo &&` 가 있었어서 삭제했습니다.
- `ApplyButton` 컴포넌트에서 `userStatus`가 없는 경우에는 `지원하기` 버튼 띄우고, 클릭 시 로그인 페이지로 redirect 시켜주었습니다.